### PR TITLE
feat(switch): switch component API change

### DIFF
--- a/packages/switch/README.md
+++ b/packages/switch/README.md
@@ -16,17 +16,16 @@ yarn add @dorai-ui/switch
 
 ## Example Usage
 
-```
+```jsx
 import { Switch } from '@dorai-ui/switch'
 
 function SwitchComponent() {
   return (
-    <Switch>
+    <Switch name='switch' {...args}>
       {({ checked }) => (
         <>
-          <Switch.Trigger id='toggle'>Click to toggle</Switch.Trigger>
-          <Switch.Label htmlFor='toggle'>toggle label</Switch.Label>
-          <p>{checked ? 'checked' : 'off'}</p>
+          <Switch.Indicator />
+          <Switch.Label>toggle label</Switch.Label>
         </>
       )}
     </Switch>

--- a/packages/switch/__tests__/switch.test.tsx
+++ b/packages/switch/__tests__/switch.test.tsx
@@ -3,22 +3,12 @@ import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { Switch } from '../lib/switch'
 
-describe('Safe rules of component', () => {
-  it.each([['Switch.Trigger', Switch.Trigger]])(
-    'should error if component is rendered without a parent <Switch />',
-    (name, Component) => {
-      expect(() => render(<Component>children</Component>)).toThrowError(
-        `<${name} /> component is not called within expected parent component`
-      )
-    }
-  )
-})
-
 describe('switch rendering', () => {
   it('renders switch component without crashing', () => {
     render(
       <Switch>
-        <Switch.Trigger>click to toggle</Switch.Trigger>
+        <Switch.Indicator />
+        <Switch.Label>click to toggle</Switch.Label>
       </Switch>
     )
 
@@ -30,8 +20,8 @@ describe('switch rendering', () => {
       <Switch>
         {({ checked }) => (
           <>
-            <Switch.Trigger>click to toggle</Switch.Trigger>
-            <Switch.Label>Label component</Switch.Label>
+            <Switch.Indicator />
+            <Switch.Label>click to toggle</Switch.Label>
             {checked ? <p>toggle on</p> : null}
           </>
         )}
@@ -53,8 +43,8 @@ describe('switch rendering', () => {
       <Switch>
         {({ checked }) => (
           <>
-            <Switch.Trigger id='toggle'>click to toggle</Switch.Trigger>
-            <Switch.Label htmlFor='toggle'>Label component</Switch.Label>
+            <Switch.Indicator />
+            <Switch.Label>Label component</Switch.Label>
             {checked ? <p>toggle on</p> : null}
           </>
         )}

--- a/packages/switch/docs/switch.stories.tsx
+++ b/packages/switch/docs/switch.stories.tsx
@@ -2,14 +2,14 @@ import React from 'react'
 
 import { ComponentStory, ComponentMeta } from '@storybook/react'
 
-import { Switch } from '@dorai-ui/switch'
+import { Switch } from '../lib'
 
 const Template: ComponentStory<typeof Switch> = (args) => (
-  <Switch {...args}>
+  <Switch name='switch' {...args}>
     {({ checked }) => (
       <>
-        <Switch.Trigger id='toggle'>Click to toggle</Switch.Trigger>
-        <Switch.Label htmlFor='toggle'>toggle label</Switch.Label>
+        <Switch.Indicator />
+        <Switch.Label>toggle label</Switch.Label>
         <p>{checked ? 'checked' : 'off'}</p>
       </>
     )}
@@ -19,7 +19,8 @@ const Template: ComponentStory<typeof Switch> = (args) => (
 export const Controlled = Template.bind({})
 Controlled.args = {
   checked: false,
-  disabled: false
+  disabled: false,
+  onChange: undefined
 }
 
 export default {


### PR DESCRIPTION
BREAKING CHANGE: 
- Trigger child component replaced with Indicator,

- htmlFor on Label not needed anymore

- Support for value and onChange props