### PR TITLE
feat: switch Component expose Group and support external Label

### DIFF
--- a/packages/label/lib/label.tsx
+++ b/packages/label/lib/label.tsx
@@ -4,13 +4,15 @@ import { GetId, Polymorphic } from '@dorai-ui/utils'
 const LabelContext = React.createContext<{
   ids: string | undefined
   registerId: (value: string) => () => void
+  htmlFor: string | undefined
 } | null>(null)
 
 type LabelContextProps = {
   children: ((args: { ids?: string }) => JSX.Element) | React.ReactNode
+  htmlFor?: string
 }
 
-const LabelContextProvider = ({ children }: LabelContextProps) => {
+const LabelContextProvider = ({ children, htmlFor }: LabelContextProps) => {
   const [ids, setIds] = React.useState<string[]>([])
 
   const composeIds = ids.length > 0 ? ids.join(' ') : undefined
@@ -24,8 +26,8 @@ const LabelContextProvider = ({ children }: LabelContextProps) => {
   }, [])
 
   const context = React.useMemo(
-    () => ({ ids: composeIds, registerId }),
-    [composeIds, registerId]
+    () => ({ ids: composeIds, registerId, htmlFor }),
+    [composeIds, htmlFor, registerId]
   )
 
   const render = () => {
@@ -55,9 +57,7 @@ const useLabelValue = () => {
 
 /**
  *
- *
  * Label component
- *
  *
  */
 type LabelOwnProps = {
@@ -69,10 +69,6 @@ type LabelProps<C extends React.ElementType> =
 
 const __DEFAULT_LABEL_TAG__ = 'label'
 
-// type LabelType = <C extends React.ElementType = typeof __DEFAULT_LABEL_TAG__>(
-//   props: LabelProps<C>
-// ) => React.ReactElement | null
-
 const Label = React.forwardRef(
   <C extends React.ElementType = typeof __DEFAULT_LABEL_TAG__>(
     { as, children, ...props }: LabelProps<C>,
@@ -82,6 +78,8 @@ const Label = React.forwardRef(
 
     const { registerId } = context
 
+    const htmlFor = props.htmlFor || context.htmlFor
+
     const id = `dorai-ui-label-${GetId()}`
 
     React.useLayoutEffect(() => {
@@ -90,7 +88,7 @@ const Label = React.forwardRef(
 
     const TagName = as || __DEFAULT_LABEL_TAG__
     return (
-      <TagName id={id} ref={ref} {...props}>
+      <TagName id={id} ref={ref} {...props} htmlFor={htmlFor}>
         {children}
       </TagName>
     )

--- a/packages/switch/__tests__/switch.test.tsx
+++ b/packages/switch/__tests__/switch.test.tsx
@@ -6,10 +6,12 @@ import { Switch } from '../lib/switch'
 describe('switch rendering', () => {
   it('renders switch component without crashing', () => {
     render(
-      <Switch>
-        <Switch.Indicator />
+      <Switch.Group>
+        <Switch>
+          <Switch.Indicator />
+        </Switch>
         <Switch.Label>click to toggle</Switch.Label>
-      </Switch>
+      </Switch.Group>
     )
 
     expect(screen.queryByRole(/switch/i)).toBeInTheDocument()
@@ -17,15 +19,12 @@ describe('switch rendering', () => {
 
   it('toggles switch if component is clicked', () => {
     render(
-      <Switch>
-        {({ checked }) => (
-          <>
-            <Switch.Indicator />
-            <Switch.Label>click to toggle</Switch.Label>
-            {checked ? <p>toggle on</p> : null}
-          </>
-        )}
-      </Switch>
+      <Switch.Group>
+        <Switch>
+          <Switch.Indicator />
+        </Switch>
+        <Switch.Label>click to toggle</Switch.Label>
+      </Switch.Group>
     )
 
     expect(screen.queryByRole(/switch/i)).toBeInTheDocument()
@@ -35,34 +34,37 @@ describe('switch rendering', () => {
 
     userEvent.click(toggleBtn)
 
-    expect(screen.queryByText(/toggle on/i)).toBeInTheDocument()
+    expect(
+      screen.getByRole(/switch/i).getAttribute('aria-checked')
+    ).toBeTruthy()
   })
 
   it('toggles if label is clicked', () => {
     render(
-      <Switch>
-        {({ checked }) => (
-          <>
-            <Switch.Indicator />
-            <Switch.Label>Label component</Switch.Label>
-            {checked ? <p>toggle on</p> : null}
-          </>
-        )}
-      </Switch>
+      <Switch.Group>
+        <Switch>
+          <Switch.Indicator />
+        </Switch>
+        <Switch.Label>Label component</Switch.Label>
+      </Switch.Group>
     )
 
     const toggleBtn = screen.getByText(/Label component/i)
 
     userEvent.click(toggleBtn)
 
-    expect(screen.queryByText(/toggle on/i)).toBeInTheDocument()
+    expect(
+      screen.getByRole(/switch/i).getAttribute('aria-checked')
+    ).toBeTruthy()
   })
 
-  it('renders checked component if passed as props', () => {
+  it('renders checked props if passed as props', () => {
     render(
-      <Switch checked>
-        {({ checked }) => <>{checked ? <p>toggle on</p> : null}</>}
-      </Switch>
+      <Switch.Group>
+        <Switch checked>
+          {({ checked }) => <>{checked ? <p>toggle on</p> : null}</>}
+        </Switch>
+      </Switch.Group>
     )
 
     expect(screen.queryByText(/toggle on/i)).toBeInTheDocument()

--- a/packages/switch/docs/switch.stories.tsx
+++ b/packages/switch/docs/switch.stories.tsx
@@ -5,15 +5,17 @@ import { ComponentStory, ComponentMeta } from '@storybook/react'
 import { Switch } from '../lib'
 
 const Template: ComponentStory<typeof Switch> = (args) => (
-  <Switch name='switch' {...args}>
-    {({ checked }) => (
-      <>
-        <Switch.Indicator />
-        <Switch.Label>toggle label</Switch.Label>
-        <p>{checked ? 'checked' : 'off'}</p>
-      </>
-    )}
-  </Switch>
+  <Switch.Group>
+    <Switch name='switch' {...args}>
+      {({ checked }) => (
+        <>
+          <Switch.Indicator />
+          <p>{checked ? 'checked' : 'off'}</p>
+        </>
+      )}
+    </Switch>
+    <Switch.Label>toggle label</Switch.Label>
+  </Switch.Group>
 )
 
 export const Controlled = Template.bind({})


### PR DESCRIPTION
Switch compoent expose Group Wrapper and support external Label

BREAKING CHANGE: Component needs to be wrapped by Switch.Group to provide context