### PR TITLE
feat: remove utils from the components install

### DIFF
--- a/packages/components/README.md
+++ b/packages/components/README.md
@@ -1,6 +1,6 @@
 # `@dorai-ui/components`
 
-The accessible, unstyled fully functional components from @dorai-ui
+All accessible, unstyled fully functional components from @dorai-ui
 
 ## Installation
 
@@ -16,4 +16,4 @@ yarn add @dorai-ui/components
 
 ## Documentation
 
-Further documentation and examples can be found [here](https://watife.github.io/dorai-ui).
+Further documentation and examples can be found [here](https://www.dorai-ui.com/components/accordion).

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -34,11 +34,9 @@
     "@dorai-ui/alert": "^0.3.6",
     "@dorai-ui/alert-dialog": "^0.3.5",
     "@dorai-ui/modal": "^1.3.5",
-    "@dorai-ui/portal": "^1.2.4",
     "@dorai-ui/radio-group": "^1.2.5",
     "@dorai-ui/switch": "^3.1.5",
-    "@dorai-ui/tabs": "^2.2.5",
-    "@dorai-ui/utils": "^1.2.4"
+    "@dorai-ui/tabs": "^2.2.5"
   },
   "peerDependencies": {
     "react": "^16.8.0 || ^17.0.0 || ^18.0.0",

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -1,8 +1,6 @@
 export { Accordion } from '@dorai-ui/accordion'
 export { Modal } from '@dorai-ui/modal'
-export { DoraiPortal as Portal } from '@dorai-ui/portal'
 export { Switch } from '@dorai-ui/switch'
 export { Tabs } from '@dorai-ui/tabs'
 export { AlertDialog } from '@dorai-ui/alert-dialog'
 export { RadioGroup } from '@dorai-ui/radio-group'
-export * as Utils from '@dorai-ui/utils'


### PR DESCRIPTION
BREAKING CHANGE: dorai-ui utils are no longer part of the components and should be installed separately