### PR TITLE
fix: radio-group indicator checked state and fix accessible label on option tag

### DIFF
--- a/packages/radio-group/docs/radio-group.stories.tsx
+++ b/packages/radio-group/docs/radio-group.stories.tsx
@@ -2,13 +2,14 @@ import React from 'react'
 
 import { ComponentStory, ComponentMeta } from '@storybook/react'
 
-import { RadioGroup } from '../src'
+import { RadioGroup } from '@dorai-ui/radio-group'
 
 const Template: ComponentStory<typeof RadioGroup> = (args) => {
-  const [value, setValue] = React.useState(null)
+  const [value, setValue] = React.useState('')
 
   return (
     <RadioGroup {...args} value={value} onChange={setValue}>
+      <RadioGroup.Label>Example Radio</RadioGroup.Label>
       <RadioGroup.Option
         value='option 1'
         style={{
@@ -25,6 +26,7 @@ const Template: ComponentStory<typeof RadioGroup> = (args) => {
             borderRadius: '50%',
             content: "' '"
           }}
+          as='div'
         />
         <RadioGroup.Label
           style={{
@@ -59,6 +61,7 @@ const Template: ComponentStory<typeof RadioGroup> = (args) => {
             height: '10px',
             borderRadius: '50%'
           }}
+          as='div'
         />
       </RadioGroup.Option>
     </RadioGroup>

--- a/packages/radio-group/src/radio-group.tsx
+++ b/packages/radio-group/src/radio-group.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { KeyBoardKeys, mergeRefs, Polymorphic } from '@dorai-ui/utils'
+import { GetId, KeyBoardKeys, mergeRefs, Polymorphic } from '@dorai-ui/utils'
 import { LabelContextProvider, useLabelValue, Label } from '@dorai-ui/label'
 
 /**
@@ -203,6 +203,8 @@ const Option: OptionType = React.forwardRef(
     const internalRef = React.useRef<HTMLElement | null>(null)
     const mergedRefs = mergeRefs([internalRef, ref])
 
+    const id = `dorai-ui-radiogroup-${GetId()}`
+
     const {
       options,
       handleSetActiveOption,
@@ -309,26 +311,32 @@ const Option: OptionType = React.forwardRef(
     }
 
     return (
-      <OptionContext.Provider value={{ checked }}>
-        <TagName
-          role='radio'
-          onClick={!disabled ? handleClickEvent : undefined}
-          onKeyDown={handleKeyPress}
-          aria-checked={checked ? true : false}
-          value={optionValue}
-          data-value={optionValue}
-          onFocus={
-            !disabled ? () => handleSetActiveOption(internalRef) : undefined
-          }
-          onBlur={!disabled ? () => handleBlurOption() : undefined}
-          tabIndex={getTabIndex()}
-          aria-disabled={disabled}
-          ref={mergedRefs}
-          {...props}
-        >
-          {render()}
-        </TagName>
-      </OptionContext.Provider>
+      <LabelContextProvider htmlFor={id}>
+        {({ ids }) => (
+          <OptionContext.Provider value={{ checked }}>
+            <TagName
+              id={id}
+              role='radio'
+              onClick={!disabled ? handleClickEvent : undefined}
+              onKeyDown={handleKeyPress}
+              aria-labelledby={ids}
+              aria-checked={checked}
+              value={optionValue}
+              data-value={optionValue}
+              onFocus={
+                !disabled ? () => handleSetActiveOption(internalRef) : undefined
+              }
+              onBlur={!disabled ? () => handleBlurOption() : undefined}
+              tabIndex={getTabIndex()}
+              aria-disabled={disabled}
+              ref={mergedRefs}
+              {...props}
+            >
+              {render()}
+            </TagName>
+          </OptionContext.Provider>
+        )}
+      </LabelContextProvider>
     )
   }
 )
@@ -376,7 +384,7 @@ const Indicator: IndicatorType = React.forwardRef(
     const TagName = as || __DEFAULT_INDICATOR_TAG__
 
     return (
-      <TagName ref={ref} {...props} data-checked={!checked}>
+      <TagName ref={ref} {...props} data-checked={checked}>
         {children}
       </TagName>
     )


### PR DESCRIPTION
The indicator tag wasn't reflecting the checked state of the option.

Add accessible label to option tag