### PR TITLE
fix: close modal not working without overlay component

### DIFF
--- a/documentation/docs/components/modal.mdx
+++ b/documentation/docs/components/modal.mdx
@@ -162,12 +162,13 @@ const ModalComp = () => (
 
 Modal is the parent component for all other components, it exposes the context and is required.
 
-| Props        | Default        | Type                   | Description                                                                                   |
-| ------------ | -------------- | ---------------------- | --------------------------------------------------------------------------------------------- |
-| isOpen       | false          | Boolean                | For controlled state, the isOpen property is required and controls the state of the component |
-| setIsOpen    | -              | Function               | Required for component state control ability                                                  |
-| initialFocus | firstFocusable | React.MutableRefObject | Handles component to receive first focus when the modal is opened. Must be a focuable element |
-| as           | 'button'       | HTMLElement            | This grants the ability to change the element this component should render as                 |
+| Props         | Default        | Type                   | Description                                                                                                              |
+| ------------- | -------------- | ---------------------- | ------------------------------------------------------------------------------------------------------------------------ |
+| isOpen        | false          | Boolean                | For controlled state, the isOpen property is required and controls the state of the component                            |
+| setIsOpen     | -              | Function               | Required for component state control ability                                                                             |
+| persistOnOpen | false          | Boolean                | When set to true, outside clicks on modal do not close the modal but modal can still be closed using the close component |
+| initialFocus  | firstFocusable | React.MutableRefObject | Handles component to receive first focus when the modal is opened. Must be a focuable element                            |
+| as            | 'button'       | HTMLElement            | This grants the ability to change the element this component should render as                                            |
 
 <br />
 

--- a/packages/modal/__tests__/modal.test.tsx
+++ b/packages/modal/__tests__/modal.test.tsx
@@ -1,6 +1,6 @@
-import React from 'react'
 import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
+import React from 'react'
 import { Modal } from '../src/modal'
 
 type ModalCompType = {
@@ -92,6 +92,35 @@ describe('Modal render', () => {
     userEvent.click(modalBtn)
 
     userEvent.click(screen.getByText(/close modal/i))
+
+    expect(screen.queryByRole(/dialog/i)).not.toBeInTheDocument()
+    expect(screen.queryByText(/title/i)).not.toBeInTheDocument()
+    expect(screen.queryByText(/Modal description/i)).not.toBeInTheDocument()
+  })
+
+  it('closes Modal when overlay is absent and outside modal is clicked', () => {
+    render(
+      <div data-testid='body'>
+        <Modal>
+          <Modal.Trigger>Open modal</Modal.Trigger>
+          <Modal.Group>
+            <Modal.Title>Title</Modal.Title>
+            <Modal.Description>Modal description</Modal.Description>
+            <Modal.Close>Close modal</Modal.Close>
+          </Modal.Group>
+        </Modal>
+      </div>
+    )
+
+    const modalBtn = screen.getByText(/open modal/i)
+
+    userEvent.click(modalBtn)
+
+    expect(screen.queryByText(/title/i)).toBeInTheDocument()
+
+    const bodyTag = screen.getByTestId('body')
+
+    userEvent.click(bodyTag)
 
     expect(screen.queryByRole(/dialog/i)).not.toBeInTheDocument()
     expect(screen.queryByText(/title/i)).not.toBeInTheDocument()

--- a/packages/modal/docs/modal.stories.tsx
+++ b/packages/modal/docs/modal.stories.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 
-import { ComponentStory, ComponentMeta } from '@storybook/react'
 import { useArgs } from '@storybook/client-api'
+import { ComponentMeta, ComponentStory } from '@storybook/react'
 
 import { Modal } from '@dorai-ui/modal'
 
@@ -76,6 +76,7 @@ export default {
   component: Modal,
   args: {
     isOpen: false,
+    persistOnOpen: true,
     // eslint-disable-next-line @typescript-eslint/no-empty-function
     onClick: () => {}
   }

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -27,6 +27,7 @@
     "polymorphic",
     "use-focus-lock",
     "use-portal",
+    "use-outside-click",
     "README.md"
   ],
   "publishConfig": {
@@ -49,7 +50,8 @@
       "merge-refs.ts",
       "polymorphic.ts",
       "use-focus-lock.ts",
-      "use-portal.ts"
+      "use-portal.ts",
+      "use-outside-click.ts"
     ]
   }
 }

--- a/packages/utils/src/use-outside-click.ts
+++ b/packages/utils/src/use-outside-click.ts
@@ -1,0 +1,23 @@
+import React from 'react'
+
+function useOutsideClick(
+  ref: React.MutableRefObject<HTMLElement | null>,
+  handler: (event: MouseEvent) => void
+) {
+  const handleMouseEvent = React.useCallback(
+    (event: MouseEvent) => {
+      if (!ref.current || ref.current.contains(event.target as Node)) return
+      handler(event)
+    },
+    [handler, ref]
+  )
+
+  React.useEffect(() => {
+    window.addEventListener('mousedown', handleMouseEvent)
+    return () => {
+      window.removeEventListener('mousedown', handleMouseEvent)
+    }
+  }, [handleMouseEvent])
+}
+
+export { useOutsideClick }

--- a/packages/utils/use-outside-click/package.json
+++ b/packages/utils/use-outside-click/package.json
@@ -1,0 +1,4 @@
+{
+  "main": "dist/dorai-ui-utils-use-outside-click.cjs.js",
+  "module": "dist/dorai-ui-utils-use-outside-click.esm.js"
+}


### PR DESCRIPTION
- When the modal overlay is not used, it is impossible to close the modal when we click outside of the modal. 
- Improve with a prop (persistOnOpen) to prevent automatic closure of the modal when you click on overlay or outside modal component.